### PR TITLE
fix bug creating tarball with files

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,10 @@ function tar(dir, tarFile, options) {
   options.exclude = _.toArrayIfNeeded(options.exclude);
 
   let files = nfile.glob(dir);
-  if (options.cwd && _.startsWith(dir, options.cwd)) {
-    files = _.map(files, f => nfile.relativize(f, options.cwd));
+  if (options.cwd) {
+    files = _.map(files, f => {
+      return _.startsWith(f, options.cwd) ? nfile.relativize(f, options.cwd) : f;
+    });
     options.exclude = _.map(options.exclude, f => nfile.relativize(f, options.cwd));
   }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const find = require('common-utils').find;
 
 /**
  * Create tar file
- * @param  {string} dir - Glob expression for aim directory
+ * @param  {string|string[]} dir - Glob expression (or array of them) for aim directory
  * @param  {string} tarFile - Target tar file
  * @param  {Object} [options]
  * @param  {string} [options.cwd=null] - Directory where the command is executed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tarball-utils",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Utils for working with tarballs",
   "main": "index.js",
   "scripts": {

--- a/test/spec.js
+++ b/test/spec.js
@@ -41,6 +41,38 @@ describe('#tar()', () => {
       'folder1/folder2/folder3/\nfolder1/folder2/folder3/file\n');
   });
 
+  it('packs files relatizing to cwd', () => {
+    s.createFilesFromManifest({
+      folder1: {
+        folder2: {
+          folder3: {file: ''}
+        }
+      }
+    });
+    const dest = s.normalize('archive.tar.gz');
+
+    tu.tar(s.normalize('folder1/folder2/folder3/file'), dest, {cwd: s.normalize('folder1/folder2')});
+
+    expect(spawnSync('tar', ['-tzf', dest]).stdout.toString(), 'Tarball content doesn\'t fit expectations').to.be
+      .eql('folder3/file\n');
+  });
+
+  it('packs folder relatizing to cwd', () => {
+    s.createFilesFromManifest({
+      folder1: {
+        folder2: {
+          folder3: {file: ''}
+        }
+      }
+    });
+    const dest = s.normalize('archive.tar.gz');
+
+    tu.tar(s.normalize('folder1/folder2/folder3'), dest, {cwd: s.normalize('folder1/folder2')});
+
+    expect(spawnSync('tar', ['-tzf', dest]).stdout.toString(), 'Tarball content doesn\'t fit expectations').to.be
+      .eql('folder3/\nfolder3/file\n');
+  });
+
   it('matches some items with a glob', () => {
     s.createFilesFromManifest({
       folder1: {


### PR DESCRIPTION
This fixes the issue when creating a tarball passing explicitly files and specifying the cwd. Paths weren't being relativized to the cwd.